### PR TITLE
#298 Remove race condition that was preventing ping thread from stopping

### DIFF
--- a/test/proxysql_ping_thread.py
+++ b/test/proxysql_ping_thread.py
@@ -29,13 +29,11 @@ class ProxySQL_Ping_Thread(Thread):
 		self.db = db
 		self.ping_command = ping_command
 		self.interval = interval
-		self.running = False
+		self.running = True
 		self.failed_connections = 0
 		super(ProxySQL_Ping_Thread, self).__init__(**kwargs)
 
 	def run(self):
-		self.running = True
-
 		while self.running:
 			time.sleep(self.interval)
 


### PR DESCRIPTION
The thread would set self.running to True after the test suite was
setting it to false, transforming the thread.join() call in the tests
in an infinite wait.